### PR TITLE
Added an common Interface base class

### DIFF
--- a/Editor/project.lua
+++ b/Editor/project.lua
@@ -55,7 +55,8 @@ linkoptions { "/ignore:4075" }
 -- Shared Defines
 
   defines { "_CRT_SECURE_NO_WARNINGS" }
-  defines { "atSHAREDLIB" }
+  
+  defines { "flCOMPILESHARED" }
 
 -- Includes
   includedirs { "source/" } 

--- a/Engine/source/flConfig.h
+++ b/Engine/source/flConfig.h
@@ -1,0 +1,21 @@
+#ifndef flConfig_h__
+#define flConfig_h__
+
+#include <stdint.h>
+
+#ifdef flSTATICLIB
+#define flEXPORT
+#define flCCONV
+#else
+#ifdef flCOMPILESHARED
+#define flEXPORT _declspec(dllexport)
+#else
+#define flEXPORT _declspec(dllimport)
+#endif
+#define flCCONV _cdecl
+#endif
+
+#define flNew new
+#define flDelete delete
+
+#endif // flConfig_h__

--- a/Engine/source/flInterface.cpp
+++ b/Engine/source/flInterface.cpp
@@ -1,0 +1,30 @@
+#include "flInterface.h"
+
+using namespace flEngine;
+
+Interface::Interface()
+  : m_refCount(1) // Default to 1 for the creator
+{}
+
+Interface::~Interface() {}
+
+void Interface::DecRef()
+{
+  if (--m_refCount == 0)
+    Destroy();
+}
+
+void Interface::Destroy()
+{
+  flDelete this;
+}
+
+void flEngine::Interface::IncRef()
+{
+  ++m_refCount;
+}
+
+int64_t Interface::GetReferenceCount() const
+{
+  return m_refCount;
+}

--- a/Engine/source/flInterface.h
+++ b/Engine/source/flInterface.h
@@ -1,0 +1,82 @@
+#ifndef flInterface_h__
+#define flInterface_h__
+
+#include "flConfig.h"
+
+namespace flEngine
+{
+  /**
+   * @brief Engine API base class.
+   *
+   * The Interface class is the common base class of the Engines components
+   * and implements common behaviors. These are:
+   *   1. Reference Counting [IncRef(), DecRef()]
+   *   2. Object destruction [Destroy()]
+   */
+  class flEXPORT Interface
+  {
+  public:
+    /**
+     * @brief Increment the interface reference count.
+     *
+     * This function will increment the internal reference count for this
+     * interface instance. Each IncRef() call should have a corresponding
+     * DecRef() call (unless the interface is explicitly destroyed using 
+     * the Destroy() function, though be careful doing this).
+     */
+    void IncRef();
+
+    /**
+     * @brief Decrement the Interface reference count.
+     *
+     * This function will decrement the internal reference count for this
+     * interface instance. If, after decrementing the reference count, it
+     * is 0, the interface will be destroyed.
+     *
+     * For that reason, after calling this function the pointer to the interface
+     * should not be used (although there is nothing stopping you from doing so).
+     */
+    void DecRef();
+
+    /**
+     * @brief Explicitly destroy the Interface instance.
+     *
+     * This function will destruct the interface instance. Using DecRef() should
+     * be preferred in case there are still outstanding active references to the
+     * interface.
+     *
+     * This will invalidate the pointer to the interface.
+     */
+    void Destroy();
+
+    /**
+     * @brief Get the active reference count.
+     *
+     * This function returns the number of references acquired through the IncRef
+     * function. This will always return 1 or greater.
+     */
+    int64_t GetReferenceCount() const;
+
+  protected:
+    /**
+    * @brief Construct a new Interface.
+    *
+    * Interface object constructor. This is protected as only derived classes should
+    * construct Interface instances.
+    */
+    Interface();
+
+  private:
+    /**
+    * @brief Destruct an Interface instance.
+    *
+    * Interface object destructor. This is private as Engine API objects should only be
+    * destroyed via the DecRef() or Destroy() functions.
+    */
+    virtual ~Interface();
+
+    int64_t m_refCount = 0; // Internal reference count
+  };
+}
+
+#endif // flInterface_h__


### PR DESCRIPTION
- Added a flConfig.h which will define compile time settings (e.g. _declspec, calling convention, etc)
- Interface class implements reference counting so that all API objects will have common IncRef, DecRef, GetReferenceCount, and Destroy functions.
- For ease of use a template wrapper for RAII-like behaviour could also be implemented. There should be a threaded and non-threaded version. This would not be passed around the API, but could be used internally and externally to properly manage object lifetime.